### PR TITLE
Set dhcp_server to required in ClientClass form

### DIFF
--- a/netbox_dhcp/forms/client_class.py
+++ b/netbox_dhcp/forms/client_class.py
@@ -87,6 +87,11 @@ class ClientClassForm(
         widget=forms.Select(choices=BOOLEAN_WITH_BLANK_CHOICES),
     )
 
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+        self.fields["dhcp_server"].required = True
+
 
 class ClientClassFilterForm(
     NetBoxDHCPFilterFormMixin,


### PR DESCRIPTION
Same problem as in #53 - a required field must be enforced by the form, but isn't.